### PR TITLE
Changed the test case duration to seconds.

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ module.exports = (report) => {
           _attr: {
             classname: tc.fullName,
             name: tc.fullName,
-            time: tc.duration
+            time: tc.duration / 1000
           }
         }]
       };


### PR DESCRIPTION
Currently the test suite duration is in the correct format, but the individual test case duration is being output in milliseconds, rather than seconds like the JUnit file format expects.

I've made a simple change here that will correct that.