### PR TITLE
Skip empty test suites to prevent crash

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = (report) => {
   // Iterate through outer testResults (test suites)
   report.testResults.forEach((suite) => {
     // Skip empty test suites
-    if (!suite.testResults[0]) {
+    if (suite.testResults.length <= 0) {
       return;
     }
 

--- a/index.js
+++ b/index.js
@@ -34,6 +34,11 @@ module.exports = (report) => {
 
   // Iterate through outer testResults (test suites)
   report.testResults.forEach((suite) => {
+    // Skip empty test suites
+    if (!suite.testResults[0]) {
+      return;
+    }
+
     // Add <testsuite /> properties
     let testSuite = {
       'testsuite': [{


### PR DESCRIPTION
If any of the test suites are empty, `jest-junit` will crash because there are no test results for the test suite (meaning `suite.testResults[0]` will be undefined):

> TypeError: Cannot read property 'ancestorTitles' of undefined
>     at report.testResults.forEach (...\node_modules\jest-junit\index.js:41:37)
>     at Array.forEach (native)
>     at module.exports (...\node_modules\jest-junit\index.js:36:22)
>     at source.getTestPaths.then.then.then.runResults (...\node_modules\jest-cli\build\jest.js:235:58)
>     at process._tickCallback (internal/process/next_tick.js:103:7)

This is annoying when running Jest in watch mode - for example, adding a new test file will cause it to crash and require a restart (*after* adding tests to the new file, or it will just crash again).

Skipping empty test suites (or, rather, suites with no test results) when generating the JUnit report fixes this.