### PR TITLE
Separate className and title

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,8 +59,8 @@ module.exports = (report) => {
       let testCase = {
         'testcase': [{
           _attr: {
-            classname: tc.fullName,
-            name: tc.fullName,
+            classname: tc.ancestorTitles.join(' '),
+            name: tc.title,
             time: tc.duration / 1000
           }
         }]


### PR DESCRIPTION
First of all, thanks for this great module!

I have a Jest spec that roughly looks like this:

    describe('<Main />', () => {
        describe('in some state', () => {
            it('should work', () => {
            });
        });
    });

It yields the following JUnit report

    <testsuites name="jest tests">
      <testsuite name="&lt;Main /&gt;" tests="2" errors="0" failures="0" skipped="0" timestamp="2017-02-18T18:42:22" time="1.898">
        <testcase classname="&lt;Main /&gt; in some state should work" name="&lt;Main /&gt; in some state should work" time="0">
        </testcase>
      </testsuite>
    </testsuites>

Note that the `classname` and the `name` have the same value.

In traditional Java projects with JUnit, `classname` contains the name of the (JUnit) test class, and `name` is the name of the test method inside that class.
Reasoning along that line, I would expect the `classname` to be a combination of all the `describe()` blocks, and the `name` the name of the `it()` block. 