### PR TITLE
Nest test failure messages in <failure> tags instead of failure->message property and strip escape codes from output

### DIFF
--- a/__mocks__/failing-tests.json
+++ b/__mocks__/failing-tests.json
@@ -1,0 +1,66 @@
+{
+  "numFailedTestSuites": 0,
+  "numFailedTests": 0,
+  "numPassedTestSuites": 1,
+  "numPassedTests": 1,
+  "numPendingTestSuites": 0,
+  "numPendingTests": 0,
+  "numRuntimeErrorTestSuites": 0,
+  "numTotalTestSuites": 1,
+  "numTotalTests": 1,
+  "snapshot": {
+    "added": 0,
+    "failure": false,
+    "filesAdded": 0,
+    "filesRemoved": 0,
+    "filesUnmatched": 0,
+    "filesUpdated": 0,
+    "matched": 0,
+    "total": 0,
+    "unchecked": 0,
+    "unmatched": 0,
+    "updated": 0
+  },
+  "startTime": 1489712747092,
+  "success": true,
+  "testResults": [
+    {
+      "console": [],
+      "failureMessage": "\u001b[1m\u001b[31m  \u001b[1m● \u001b[1mSample Failing Test › Should fail\u001b[39m\u001b[22m\n\n    foobar\n\u001b[2m      \n      \u001b[2mat _callee$ (\u001b[2m\u001b[0m\u001b[36mpath/to/failing.test.js\u001b[39m\u001b[0m\u001b[2m:26:15)\u001b[2m\n      \u001b[2mat tryCatch (\u001b[2m\u001b[0m\u001b[36mnode_modules/regenerator-runtime/runtime.js\u001b[39m\u001b[0m\u001b[2m:64:40)\u001b[2m\n      \u001b[2mat GeneratorFunctionPrototype.invoke [as _invoke] (\u001b[2m\u001b[0m\u001b[36mnode_modules/regenerator-runtime/runtime.js\u001b[39m\u001b[0m\u001b[2m:299:22)\u001b[2m\n      \u001b[2mat GeneratorFunctionPrototype.prototype.(anonymous function) [as next] (\u001b[2m\u001b[0m\u001b[36mnode_modules/regenerator-runtime/runtime.js\u001b[39m\u001b[0m\u001b[2m:116:21)\u001b[2m\n      \u001b[2mat step (\u001b[2m\u001b[0m\u001b[36mpath/to/failing.test.js\u001b[39m\u001b[0m\u001b[2m:2:394)\u001b[2m\n      \u001b[2mat \u001b[2m\u001b[0m\u001b[36mpath/to/failing.test.js\u001b[39m\u001b[0m\u001b[2m:2:554\u001b[2m\u001b[22m\n",
+      "numFailingTests": 1,
+      "numPassingTests": 0,
+      "numPendingTests": 0,
+      "perfStats": {
+        "end": 1499904221109,
+        "start": 1499904215586
+      },
+      "snapshot": {
+        "added": 0,
+        "fileDeleted": false,
+        "matched": 0,
+        "unchecked": 0,
+        "unmatched": 0,
+        "updated": 0
+      },
+      "testFilePath": "/path/to/failing.test.js",
+      "testResults": [
+        {
+          "ancestorTitles": [
+            "Sample Failing Test"
+          ],
+          "duration": 3930,
+          "failureMessages": [
+            "\u001b[1m\u001b[31m  \u001b[1m● \u001b[1mSample Failing Test › Should fail\u001b[39m\u001b[22m\n\n    foobar\n\u001b[2m      \n      \u001b[2mat _callee$ (\u001b[2m\u001b[0m\u001b[36mpath/to/failing.test.js\u001b[39m\u001b[0m\u001b[2m:26:15)\u001b[2m\n      \u001b[2mat tryCatch (\u001b[2m\u001b[0m\u001b[36mnode_modules/regenerator-runtime/runtime.js\u001b[39m\u001b[0m\u001b[2m:64:40)\u001b[2m\n      \u001b[2mat GeneratorFunctionPrototype.invoke [as _invoke] (\u001b[2m\u001b[0m\u001b[36mnode_modules/regenerator-runtime/runtime.js\u001b[39m\u001b[0m\u001b[2m:299:22)\u001b[2m\n      \u001b[2mat GeneratorFunctionPrototype.prototype.(anonymous function) [as next] (\u001b[2m\u001b[0m\u001b[36mnode_modules/regenerator-runtime/runtime.js\u001b[39m\u001b[0m\u001b[2m:116:21)\u001b[2m\n      \u001b[2mat step (\u001b[2m\u001b[0m\u001b[36mpath/to/failing.test.js\u001b[39m\u001b[0m\u001b[2m:2:394)\u001b[2m\n      \u001b[2mat \u001b[2m\u001b[0m\u001b[36mpath/to/failing.test.js\u001b[39m\u001b[0m\u001b[2m:2:554\u001b[2m\u001b[22m\n"
+          ],
+          "fullName": "Sample Failing Test Should fail",
+          "numPassingAsserts": 0,
+          "status": "failed",
+          "title": "Should fail"
+        }
+      ],
+      "sourceMaps": {},
+      "skipped": false
+    }
+  ],
+  "wasInterrupted": false
+}

--- a/__tests__/buildJsonResults.test.js
+++ b/__tests__/buildJsonResults.test.js
@@ -24,4 +24,15 @@ describe('buildJsonResults', () => {
       Object.assign({}, constants.DEFAULT_OPTIONS, { usePathForSuiteName: "true" }));
     expect(jsonResults.testsuites[1].testsuite[0]._attr.name).toBe('/__tests__/foo.test.js');
   });
+
+  it('should parse failure messages for failing tests', () => {
+    const failingTestsReport = require('../__mocks__/failing-tests.json');
+    const jsonResults = buildJsonResults(failingTestsReport, '/path/to/test', constants.DEFAULT_OPTIONS);
+
+    const failureMsg = jsonResults.testsuites[1].testsuite[1].testcase[1].failure;
+
+    // Make sure no escape codes are there that exist in the mock
+    expect(failureMsg.includes('\u001b')).toBe(false);
+
+  });
 });

--- a/package.json
+++ b/package.json
@@ -19,10 +19,11 @@
   },
   "dependencies": {
     "mkdirp": "^0.5.1",
+    "strip-ansi": "^4.0.0",
     "xml": "^1.0.1"
   },
   "devDependencies": {
-    "jest": "^19.0.2",
+    "jest": "20.0.4",
     "libxmljs": "^0.18.4"
   }
 }

--- a/utils/buildJsonResults.js
+++ b/utils/buildJsonResults.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const stripAnsi = require('strip-ansi');
 const constants = require('../constants/index');
 
 const replaceVars = function (str, classname, title) {
@@ -64,11 +65,7 @@ module.exports = function (report, appDirectory, options) {
       if (tc.status === 'failed') {
         tc.failureMessages.forEach((failure) => {
           testCase.testcase.push({
-            'failure': [{
-              _attr: {
-                message: failure || ''
-              }
-            }]
+            'failure': stripAnsi(failure)
           });
         })
       }


### PR DESCRIPTION
Builds off the work off @KidsKilla with input from @yangshun 

Original (closed) PR: https://github.com/palmerj3/jest-junit/pull/17
