### PR TITLE
Get options tests

### DIFF
--- a/__tests__/getOptions.test.js
+++ b/__tests__/getOptions.test.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+
+const getOptions = require('../utils/getOptions.js');
+
+jest.mock('fs', () => {
+  return Object.assign(
+    {},
+    require.requireActual('fs'),
+    {
+      existsSync: jest.fn().mockReturnValue(true)
+    }
+  )
+});
+
+// Mock return of require('/package.json')
+// Virtual because it doesn't actually exist
+jest.mock('/package.json', () => {
+  return {
+    name: 'foo',
+    version: '1.0.0',
+    'jest-junit': {
+      suiteName: 'test suite'
+    }
+  }
+}, {virtual: true});
+
+describe('getOptions', () => {
+  it ('should support package.json in /', () => {
+
+  });
+});

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const getOptions = require('./utils/getOptions');
   http://help.catchsoftware.com/display/ET/JUnit+Format
 */
 module.exports = (report) => {
-  const options = getOptions();
+  const options = getOptions.options();
   const jsonResults = buildJsonResults(report, fs.realpathSync(process.cwd()), options);
 
   // Ensure output path exists

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-junit",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "A jest result processor that generates junit xml files",
   "main": "index.js",
   "repository": "https://github.com/palmerj3/jest-junit",

--- a/utils/getOptions.js
+++ b/utils/getOptions.js
@@ -20,8 +20,12 @@ function getEnvOptions() {
 function getAppOptions(pathToResolve) {
   const initialPath = pathToResolve;
 
+  let traversing = true;
+
   // Find nearest package.json by traversing up directories until /
-  while(pathToResolve !== path.sep) {
+  while(traversing) {
+    traversing = pathToResolve !== path.sep;
+
     const pkgpath = path.join(pathToResolve, 'package.json');
 
     if (fs.existsSync(pkgpath)) {
@@ -40,6 +44,10 @@ function getAppOptions(pathToResolve) {
   throw new Error(`Unable to locate package.json starting at ${initialPath}`);
 }
 
-module.exports = function () {
-  return Object.assign({}, constants.DEFAULT_OPTIONS, getAppOptions(process.cwd()), getEnvOptions());
+module.exports = {
+  options: function () {
+    return Object.assign({}, constants.DEFAULT_OPTIONS, getAppOptions(process.cwd()), getEnvOptions());
+  },
+  getAppOptions: getAppOptions,
+  getEnvOptions: getEnvOptions
 };


### PR DESCRIPTION
Allows for package.json for app to live in /.
This makes it easier for tests running in docker containers and the like.

Adds unit tests for getOptions to make it easier for others to iterate on changes like this moving forward.