### PR TITLE
Don't throw if we can't find package.json

### DIFF
--- a/utils/getOptions.js
+++ b/utils/getOptions.js
@@ -41,7 +41,7 @@ function getAppOptions(pathToResolve) {
     }
   }
 
-  throw new Error(`Unable to locate package.json starting at ${initialPath}`);
+  return {};
 }
 
 module.exports = {


### PR DESCRIPTION
Don't throw if we can't find the package.json file for Jest, because it's possible to run jest without having a package.json at all.