### PR TITLE
Test against multiple versions of jest in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,10 @@
 language: node_js
 node_js:
-  - "5"
   - "6"
   - "7"
   - "8"
 env:
-  - CXX=g++-4.8
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-4.8
+  - JEST_VERSION=^20.0.0
+  - JEST_VERSION=^21.0.0
+script:
+  - npm run test:ci

--- a/integration-tests/__tests__/simple.test.js
+++ b/integration-tests/__tests__/simple.test.js
@@ -1,0 +1,5 @@
+describe('foo', () => {
+  it('should pass', () => {
+    expect(true).toEqual(true);
+  });
+});

--- a/integration-tests/jest.config.js
+++ b/integration-tests/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testResultsProcessor: '../'
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  testPathIgnorePatterns: [
+    '<rootDir>/integration-tests'
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Jason Palmer",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=6.0.0"
   },
   "files": [
     "index.js",
@@ -15,7 +15,9 @@
     "constants"
   ],
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "pretest:ci": "npm install jest@$JEST_VERSION",
+    "test:ci": "jest && jest --config ./integration-tests/jest.config.js"
   },
   "dependencies": {
     "mkdirp": "^0.5.1",
@@ -23,7 +25,6 @@
     "xml": "^1.0.1"
   },
   "devDependencies": {
-    "jest": "20.0.4",
     "libxmljs": "^0.18.4"
   }
 }


### PR DESCRIPTION
Update CI/CD so we test against multiple versions of jest.

For now this test simply runs the current unit testing suite using itself as the testResultsProcessor.