### PR TITLE
Add support for displayName template field for jest multi-project configurations

### DIFF
--- a/__mocks__/multi-project-no-failing-tests.json
+++ b/__mocks__/multi-project-no-failing-tests.json
@@ -1,0 +1,109 @@
+{
+  "numFailedTestSuites": 0,
+  "numFailedTests": 0,
+  "numPassedTestSuites": 2,
+  "numPassedTests": 2,
+  "numPendingTestSuites": 0,
+  "numPendingTests": 0,
+  "numRuntimeErrorTestSuites": 0,
+  "numTotalTestSuites": 2,
+  "numTotalTests": 2,
+  "snapshot": {
+    "added": 0,
+    "didUpdate": false,
+    "failure": false,
+    "filesAdded": 0,
+    "filesRemoved": 0,
+    "filesUnmatched": 0,
+    "filesUpdated": 0,
+    "matched": 0,
+    "total": 0,
+    "unchecked": 0,
+    "uncheckedKeys": [],
+    "unmatched": 0,
+    "updated": 0
+  },
+  "startTime": 1518274350624,
+  "success": true,
+  "testResults": [
+    {
+      "console": [],
+      "failureMessage": null,
+      "numFailingTests": 0,
+      "numPassingTests": 1,
+      "numPendingTests": 0,
+      "perfStats": {
+        "end": 1518274351263,
+        "start": 1518274351100
+      },
+      "snapshot": {
+        "added": 0,
+        "fileDeleted": false,
+        "matched": 0,
+        "unchecked": 0,
+        "unmatched": 0,
+        "updated": 0,
+        "uncheckedKeys": []
+      },
+      "testFilePath": "/path/to/project1/__tests__/test1.test.js",
+      "testResults": [
+        {
+          "ancestorTitles": [
+            "a thing"
+          ],
+          "duration": 3,
+          "failureMessages": [],
+          "fullName": "a thing should foo",
+          "location": null,
+          "numPassingAsserts": 0,
+          "status": "passed",
+          "title": "should foo"
+        }
+      ],
+      "sourceMaps": {},
+      "skipped": false,
+      "displayName": "project1",
+      "leaks": false
+    },
+    {
+      "console": [],
+      "failureMessage": null,
+      "numFailingTests": 0,
+      "numPassingTests": 1,
+      "numPendingTests": 0,
+      "perfStats": {
+        "end": 1518274351347,
+        "start": 1518274351274
+      },
+      "snapshot": {
+        "added": 0,
+        "fileDeleted": false,
+        "matched": 0,
+        "unchecked": 0,
+        "unmatched": 0,
+        "updated": 0,
+        "uncheckedKeys": []
+      },
+      "testFilePath": "/path/to/project2/__tests__/test2.test.js",
+      "testResults": [
+        {
+          "ancestorTitles": [
+            "another thing"
+          ],
+          "duration": 1,
+          "failureMessages": [],
+          "fullName": "another thing should foo",
+          "location": null,
+          "numPassingAsserts": 0,
+          "status": "passed",
+          "title": "should foo"
+        }
+      ],
+      "sourceMaps": {},
+      "skipped": false,
+      "displayName": "project2",
+      "leaks": false
+    }
+  ],
+  "wasInterrupted": false
+}

--- a/__tests__/__snapshots__/buildJsonResults.test.js.snap
+++ b/__tests__/__snapshots__/buildJsonResults.test.js.snap
@@ -1,0 +1,68 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`buildJsonResults should support displayName template var for jest multi-project 1`] = `
+Object {
+  "testsuites": Array [
+    Object {
+      "_attr": Object {
+        "failures": 0,
+        "name": "jest tests",
+        "tests": 2,
+        "time": 0.236,
+      },
+    },
+    Object {
+      "testsuite": Array [
+        Object {
+          "_attr": Object {
+            "errors": 0,
+            "failures": 0,
+            "name": "project1-foo",
+            "skipped": 0,
+            "tests": 1,
+            "time": 0.163,
+            "timestamp": "2018-02-10T14:52:31",
+          },
+        },
+        Object {
+          "testcase": Array [
+            Object {
+              "_attr": Object {
+                "classname": "a thing should foo",
+                "name": "project1-foo",
+                "time": 0.003,
+              },
+            },
+          ],
+        },
+      ],
+    },
+    Object {
+      "testsuite": Array [
+        Object {
+          "_attr": Object {
+            "errors": 0,
+            "failures": 0,
+            "name": "project2-foo",
+            "skipped": 0,
+            "tests": 1,
+            "time": 0.073,
+            "timestamp": "2018-02-10T14:52:31",
+          },
+        },
+        Object {
+          "testcase": Array [
+            Object {
+              "_attr": Object {
+                "classname": "another thing should foo",
+                "name": "project2-foo",
+                "time": 0.001,
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}
+`;

--- a/__tests__/buildJsonResults.test.js
+++ b/__tests__/buildJsonResults.test.js
@@ -99,4 +99,15 @@ describe('buildJsonResults', () => {
 
   });
 
+  it('should support displayName template var for jest multi-project', () => {
+    const multiProjectNoFailingTestsReport = require('../__mocks__/multi-project-no-failing-tests.json');
+
+    const jsonResults = buildJsonResults(multiProjectNoFailingTestsReport, '',
+    Object.assign({}, constants.DEFAULT_OPTIONS, {
+      suiteNameTemplate: "{displayName}-foo",
+      titleTemplate: "{displayName}-foo"
+    }));
+
+    expect(jsonResults).toMatchSnapshot();
+  });
 });

--- a/constants/index.js
+++ b/constants/index.js
@@ -25,4 +25,5 @@ module.exports = {
   FILENAME_VAR: '{filename}',
   FILEPATH_VAR: '{filepath}',
   TITLE_VAR: '{title}',
+  DISPLAY_NAME_VAR: '{displayName}',
 };

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "test": "jest",
     "pretest:ci": "npm install jest@$JEST_VERSION",
-    "test:ci": "jest && jest --config ./integration-tests/jest.config.js"
+    "test:ci": "jest --ci && jest --ci --config ./integration-tests/jest.config.js"
   },
   "dependencies": {
     "mkdirp": "^0.5.1",

--- a/utils/buildJsonResults.js
+++ b/utils/buildJsonResults.js
@@ -48,12 +48,14 @@ module.exports = function (report, appDirectory, options) {
     const filepath = suite.testFilePath.replace(appDirectory, '');
     const filename = path.basename(filepath);
     const suiteTitle = suite.testResults[0].ancestorTitles[0];
+    const displayName = suite.displayName;
 
     // Build replacement map
     let suiteReplacementMap = {};
     suiteReplacementMap[constants.FILEPATH_VAR] = filepath;
     suiteReplacementMap[constants.FILENAME_VAR] = filename;
     suiteReplacementMap[constants.TITLE_VAR] = suiteTitle;
+    suiteReplacementMap[constants.DISPLAY_NAME_VAR] = displayName;
 
     // Add <testsuite /> properties
     const suiteNumTests = suite.numFailingTests + suite.numPassingTests + suite.numPendingTests;
@@ -89,6 +91,7 @@ module.exports = function (report, appDirectory, options) {
       testReplacementMap[constants.FILENAME_VAR] = filename;
       testReplacementMap[constants.CLASSNAME_VAR] = classname;
       testReplacementMap[constants.TITLE_VAR] = testTitle;
+      testReplacementMap[constants.DISPLAY_NAME_VAR] = displayName;
 
       let testCase = {
         'testcase': [{


### PR DESCRIPTION
Allows you to use the "{displayName}" template override in the titleTemplate and classNameTemplate options.