### PR TITLE
Implement test suite errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ jest --ci --testResultsProcessor="jest-junit"
 | `JEST_JUNIT_TITLE` | Template string for the `name` attribute of `<testcase>`. | `"{classname} {title}"` | `{classname}`, `{title}`, `{filepath}`, `{filename}`, `{displayName}`
 | `JEST_JUNIT_ANCESTOR_SEPARATOR` | Character(s) used to join the `describe` blocks. | `" "` | N/A
 | `JEST_USE_PATH_FOR_SUITE_NAME` | **DEPRECATED. Use `suiteNameTemplate` instead.** Use file path as the `name` attribute of `<testsuite>` | `"false"` | N/A
+| `JEST_OUTPUT_SUITE_ERROR` | Outputs test suite errors. | `"true"` | N/A
 
 
 You can configure these options via the command line as seen below:

--- a/__mocks__/error-tests.json
+++ b/__mocks__/error-tests.json
@@ -42,6 +42,7 @@
         "unmatched": 0,
         "updated": 0
       },
+      "testExecError": {},
       "testFilePath": "/path/to/error.test.js",
       "testResults": []
     }

--- a/__mocks__/error-tests.json
+++ b/__mocks__/error-tests.json
@@ -1,0 +1,50 @@
+{
+  "numFailedTestSuites": 1,
+  "numFailedTests": 0,
+  "numPassedTestSuites": 1,
+  "numPassedTests": 1,
+  "numPendingTestSuites": 0,
+  "numPendingTests": 0,
+  "numRuntimeErrorTestSuites": 1,
+  "numTotalTestSuites": 1,
+  "numTotalTests": 0,
+  "snapshot": {
+    "added": 0,
+    "failure": false,
+    "filesAdded": 0,
+    "filesRemoved": 0,
+    "filesUnmatched": 0,
+    "filesUpdated": 0,
+    "matched": 0,
+    "total": 0,
+    "unchecked": 0,
+    "unmatched": 0,
+    "updated": 0
+  },
+  "startTime": 1489712747092,
+  "success": true,
+  "testResults": [
+    {
+      "console": [],
+      "failureMessage": "\u001b[1m\u001b[31m  \u001b[1m● \u001b[1mSample Error Test › Should fail\u001b[39m\u001b[22m\n\n    foobar\n\u001b[2m      \n      \u001b[2mat _callee$ (\u001b[2m\u001b[0m\u001b[36mpath/to/error.test.js\u001b[39m\u001b[0m\u001b[2m:26:15)\u001b[2m\n      \u001b[2mat tryCatch (\u001b[2m\u001b[0m\u001b[36mnode_modules/regenerator-runtime/runtime.js\u001b[39m\u001b[0m\u001b[2m:64:40)\u001b[2m\n      \u001b[2mat GeneratorFunctionPrototype.invoke [as _invoke] (\u001b[2m\u001b[0m\u001b[36mnode_modules/regenerator-runtime/runtime.js\u001b[39m\u001b[0m\u001b[2m:299:22)\u001b[2m\n      \u001b[2mat GeneratorFunctionPrototype.prototype.(anonymous function) [as next] (\u001b[2m\u001b[0m\u001b[36mnode_modules/regenerator-runtime/runtime.js\u001b[39m\u001b[0m\u001b[2m:116:21)\u001b[2m\n      \u001b[2mat step (\u001b[2m\u001b[0m\u001b[36mpath/to/error.test.js\u001b[39m\u001b[0m\u001b[2m:2:394)\u001b[2m\n      \u001b[2mat \u001b[2m\u001b[0m\u001b[36mpath/to/error.test.js\u001b[39m\u001b[0m\u001b[2m:2:554\u001b[2m\u001b[22m\n",
+      "numFailingTests": 0,
+      "numPassingTests": 0,
+      "numPendingTests": 0,
+      "perfStats": {
+        "end": 0,
+        "start": 0
+      },
+      "snapshot": {
+        "added": 0,
+        "fileDeleted": false,
+        "matched": 0,
+        "unchecked": 0,
+        "unmatched": 0,
+        "updated": 0
+      },
+      "testFilePath": "/path/to/error.test.js",
+      "testResults": []
+    }
+  ],
+  "wasInterrupted": false
+}

--- a/__tests__/__snapshots__/buildJsonResults.test.js.snap
+++ b/__tests__/__snapshots__/buildJsonResults.test.js.snap
@@ -5,6 +5,7 @@ Object {
   "testsuites": Array [
     Object {
       "_attr": Object {
+        "errors": 0,
         "failures": 0,
         "name": "jest tests",
         "tests": 2,

--- a/__tests__/buildJsonResults.test.js
+++ b/__tests__/buildJsonResults.test.js
@@ -88,6 +88,25 @@ describe('buildJsonResults', () => {
     expect(jsonResults.testsuites[1].testsuite[1].testcase[0]._attr.classname).toBe('foo › baz should bar');
   });
 
+  it('should contain error messages for error tests', () => {
+    const errorTestsReport = require('../__mocks__/error-tests.json');
+    const jsonResults = buildJsonResults(errorTestsReport, '/path/to/test', constants.DEFAULT_OPTIONS);
+    expect(jsonResults.testsuites[0]._attr.errors).toBe(1);
+  });
+
+  it('should not contain error messages for error tests when outputSuiteError is "false"', () => {
+    const errorTestsReport = require('../__mocks__/error-tests.json');
+    const jsonResults = buildJsonResults(errorTestsReport, '/path/to/test', 
+      Object.assign({}, constants.DEFAULT_OPTIONS, { outputSuiteError: "false" }));
+    expect(jsonResults.testsuites[0]._attr.errors).toBe(0);
+  });
+
+  it('should display an error for error tests', () => {
+    const errorTestsReport = require('../__mocks__/error-tests.json');
+    const jsonResults = buildJsonResults(errorTestsReport, '/path/to/test', constants.DEFAULT_OPTIONS);
+    expect(jsonResults.testsuites[1].testsuite[1].error).toBeDefined();
+  });
+
   it('should parse failure messages for failing tests', () => {
     const failingTestsReport = require('../__mocks__/failing-tests.json');
     const jsonResults = buildJsonResults(failingTestsReport, '/path/to/test', constants.DEFAULT_OPTIONS);

--- a/constants/index.js
+++ b/constants/index.js
@@ -11,6 +11,7 @@ module.exports = {
     JEST_JUNIT_TITLE: 'titleTemplate',
     JEST_JUNIT_ANCESTOR_SEPARATOR: 'ancestorSeparator',
     JEST_USE_PATH_FOR_SUITE_NAME: 'usePathForSuiteName',
+	  JEST_OUTPUT_SUITE_ERROR: 'outputSuiteError',
   },
   DEFAULT_OPTIONS: {
     suiteName: 'jest tests',
@@ -20,6 +21,7 @@ module.exports = {
     titleTemplate: '{classname} {title}',
     ancestorSeparator: ' ',
     usePathForSuiteName: 'false',
+	  outputSuiteError: 'true',
   },
   CLASSNAME_VAR: '{classname}',
   FILENAME_VAR: '{filename}',

--- a/utils/buildJsonResults.js
+++ b/utils/buildJsonResults.js
@@ -33,9 +33,7 @@ module.exports = function (report, appDirectory, options) {
   report.testResults.forEach((suite) => {
     //Detect suite errors. This is ignored if outputSuiteFailure setting is false
     //Consider failure messages withoiut test cases to be an error
-    const testSuiteError = options.outputSuiteError  === 'true' 
-      && (typeof suite.failureMessage === "string" && suite.failureMessage.length > 0) 
-      && suite.testResults.length <= 0;
+    const testSuiteError = options.outputSuiteError  === 'true' && suite.testExecError;
     
     // Skip empty test suites which did not error out
     if (!testSuiteError && suite.testResults.length <= 0) {

--- a/utils/buildJsonResults.js
+++ b/utils/buildJsonResults.js
@@ -22,6 +22,7 @@ module.exports = function (report, appDirectory, options) {
           'name': options.suiteName,
           'tests': 0,
           'failures': 0,
+          'errors': 0,
           'time': 0
         }
       }
@@ -30,8 +31,14 @@ module.exports = function (report, appDirectory, options) {
 
   // Iterate through outer testResults (test suites)
   report.testResults.forEach((suite) => {
-    // Skip empty test suites
-    if (suite.testResults.length <= 0) {
+    //Detect suite errors. This is ignored if outputSuiteFailure setting is false
+    //Consider failure messages withoiut test cases to be an error
+    const testSuiteError = options.outputSuiteError  === 'true' 
+      && (typeof suite.failureMessage === "string" && suite.failureMessage.length > 0) 
+      && suite.testResults.length <= 0;
+    
+    // Skip empty test suites which did not error out
+    if (!testSuiteError && suite.testResults.length <= 0) {
       return;
     }
 
@@ -47,7 +54,8 @@ module.exports = function (report, appDirectory, options) {
     // Build variables for suite name
     const filepath = suite.testFilePath.replace(appDirectory, '');
     const filename = path.basename(filepath);
-    const suiteTitle = suite.testResults[0].ancestorTitles[0];
+    //Use filepath as suite title if suite errored, as they would not have any tests
+    const suiteTitle = testSuiteError ? filepath : suite.testResults[0].ancestorTitles[0];
     const displayName = suite.displayName;
 
     // Build replacement map
@@ -65,7 +73,7 @@ module.exports = function (report, appDirectory, options) {
       'testsuite': [{
         _attr: {
           name: replaceVars(options.suiteNameTemplate, suiteReplacementMap),
-          errors: 0,  // not supported
+          errors: testSuiteError ? 1 : 0,
           failures: suite.numFailingTests,
           skipped: suite.numPendingTests,
           timestamp: (new Date(suite.perfStats.start)).toISOString().slice(0, -5),
@@ -78,8 +86,16 @@ module.exports = function (report, appDirectory, options) {
     // Update top level testsuites properties
     jsonResults.testsuites[0]._attr.failures += suite.numFailingTests;
     jsonResults.testsuites[0]._attr.tests += suiteNumTests;
+	  jsonResults.testsuites[0]._attr.errors += testSuiteError ? 1 : 0;
     jsonResults.testsuites[0]._attr.time += suiteExecutionTime;
-
+	
+    //Push test message and increment failures and test count by one
+    if (testSuiteError){
+      testSuite.testsuite.push({
+        'error': stripAnsi(suite.failureMessage)
+      });
+    }
+	
     // Iterate through test cases
     suite.testResults.forEach((tc) => {
       const classname = tc.ancestorTitles.join(options.ancestorSeparator);


### PR DESCRIPTION
This change was made to capture and output test errors (as opposed to failures) when a test is invalid for various reasons (for example, broken test files). 
Previously if a test suite has errored out, jest-junit would display that no tests ran and no test failed, which may incorrectly imply that nothing went wrong.

Please let me know if you have further questions.
Thanks!