### PR TITLE
Calculate overall test suites time from actual run time

### DIFF
--- a/__tests__/__snapshots__/buildJsonResults.test.js.snap
+++ b/__tests__/__snapshots__/buildJsonResults.test.js.snap
@@ -8,7 +8,7 @@ Object {
         "failures": 0,
         "name": "jest tests",
         "tests": 2,
-        "time": 0.236,
+        "time": 1.234,
       },
     },
     Object {

--- a/__tests__/buildJsonResults.test.js
+++ b/__tests__/buildJsonResults.test.js
@@ -102,6 +102,10 @@ describe('buildJsonResults', () => {
   it('should support displayName template var for jest multi-project', () => {
     const multiProjectNoFailingTestsReport = require('../__mocks__/multi-project-no-failing-tests.json');
 
+    // Mock Date.now() to return a fixed later value
+    const startDate = new Date(multiProjectNoFailingTestsReport.startTime);
+    spyOn(Date, 'now').and.returnValue(startDate.getTime() + 1234);
+
     const jsonResults = buildJsonResults(multiProjectNoFailingTestsReport, '',
     Object.assign({}, constants.DEFAULT_OPTIONS, {
       suiteNameTemplate: "{displayName}-foo",

--- a/utils/buildJsonResults.js
+++ b/utils/buildJsonResults.js
@@ -13,6 +13,10 @@ const replaceVars = function (str, replacementMap) {
   return str;
 };
 
+const executionTime = function (startTime, endTime) {
+  return (endTime - startTime) / 1000;
+}
+
 module.exports = function (report, appDirectory, options) {
   // Generate a single XML file for all jest tests
   let jsonResults = {
@@ -22,7 +26,10 @@ module.exports = function (report, appDirectory, options) {
           'name': options.suiteName,
           'tests': 0,
           'failures': 0,
-          'time': 0
+          // Overall execution time:
+          // Since tests are typically executed in parallel this time can be significantly smaller
+          // than the sum of the individual test suites
+          'time': executionTime(report.startTime, Date.now())
         }
       }
     ]
@@ -59,7 +66,7 @@ module.exports = function (report, appDirectory, options) {
 
     // Add <testsuite /> properties
     const suiteNumTests = suite.numFailingTests + suite.numPassingTests + suite.numPendingTests;
-    const suiteExecutionTime = (suite.perfStats.end - suite.perfStats.start) / 1000;
+    const suiteExecutionTime = executionTime(suite.perfStats.start, suite.perfStats.end);
 
     let testSuite = {
       'testsuite': [{
@@ -78,7 +85,6 @@ module.exports = function (report, appDirectory, options) {
     // Update top level testsuites properties
     jsonResults.testsuites[0]._attr.failures += suite.numFailingTests;
     jsonResults.testsuites[0]._attr.tests += suiteNumTests;
-    jsonResults.testsuites[0]._attr.time += suiteExecutionTime;
 
     // Iterate through test cases
     suite.testResults.forEach((tc) => {


### PR DESCRIPTION
The current time is based on summing up the individual test suites, which would assume that the individual test suites are executed in sequence. Since Jest by default executes the tests in parallel (possibly with some caching) the overall test time is typically significantly shorter.

This PR changes the overall test suites time to reflect the total runtime based from reported start time until the test run is done instead (when the reporter is called).

I understand that this could be a breaking change for some, so an alternative solution could be to keep current behavior but enable this new behavior through an options flag (o vice versa). Not sure if that's necessary through, so I created the PR with this small change to get some initial feedback.

Thoughts?